### PR TITLE
Add option for custom prettyfier of caller information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # IDE
 *.code-workspace
+.idea/

--- a/tests/formatter_test.go
+++ b/tests/formatter_test.go
@@ -3,7 +3,10 @@ package formatter_test
 import (
 	"bytes"
 	"os"
+	"path"
 	"regexp"
+	"runtime"
+	"strings"
 	"testing"
 
 	formatter "github.com/antonfisher/nested-logrus-formatter"
@@ -181,6 +184,86 @@ func TestFormatter_Format_with_report_caller(t *testing.T) {
 	}
 
 	expectedRegExp := "- \\[DEBU\\] test1 \\(.+\\.go:[0-9]+ .+\\)\n$"
+	match, err := regexp.MatchString(
+		expectedRegExp,
+		line,
+	)
+	if err != nil {
+		t.Errorf("Cannot check regexp: %v", err)
+	} else if !match {
+		t.Errorf(
+			"logger.SetReportCaller(true) output doesn't match, expected: %s to find in: '%s'",
+			expectedRegExp,
+			line,
+		)
+	}
+}
+
+func TestFormatter_Format_with_report_caller_and_CallerFirst_true(t *testing.T) {
+	output := bytes.NewBuffer([]byte{})
+
+	l := logrus.New()
+	l.SetOutput(output)
+	l.SetLevel(logrus.DebugLevel)
+	l.SetFormatter(&formatter.Formatter{
+		NoColors:        true,
+		TimestampFormat: "-",
+		CallerFirst: true,
+	})
+	l.SetReportCaller(true)
+
+	l.Debug("test1")
+
+	line, err := output.ReadString('\n')
+	if err != nil {
+		t.Errorf("Cannot read log output: %v", err)
+	}
+
+	//expectedRegExp := "- \\[DEBU\\] test1 \\(.+\\.go:[0-9]+ .+\\)\n$"
+	expectedRegExp := "- \\(.+\\.go:[0-9]+ .+\\) \\[DEBU\\] test1\n$"
+	match, err := regexp.MatchString(
+		expectedRegExp,
+		line,
+	)
+	t.Log(line)
+	if err != nil {
+		t.Errorf("Cannot check regexp: %v", err)
+	} else if !match {
+		t.Errorf(
+			"logger.SetReportCaller(true) output doesn't match, expected: %s to find in: '%s'",
+			expectedRegExp,
+			line,
+		)
+	}
+}
+
+func TestFormatter_Format_with_report_caller_and_CustomCallerPrettyfier(t *testing.T) {
+	output := bytes.NewBuffer([]byte{})
+
+	l := logrus.New()
+	l.SetOutput(output)
+	l.SetLevel(logrus.DebugLevel)
+	l.SetFormatter(&formatter.Formatter{
+		NoColors:        true,
+		TimestampFormat: "-",
+		CallerFirst: true,
+		CustomCallerPrettyfier: func(f *runtime.Frame) string {
+			s := strings.Split(f.Function, ".")
+			funcName := s[len(s)-1]
+			return fmt.Sprintf(" [%s:%d][%s()]", path.Base(f.File), f.Line, funcName)
+		},
+	})
+	l.SetReportCaller(true)
+
+	l.Debug("test1")
+
+	line, err := output.ReadString('\n')
+	if err != nil {
+		t.Errorf("Cannot read log output: %v", err)
+	}
+
+	//expectedRegExp := "- \\[DEBU\\] test1 \\(.+\\.go:[0-9]+ .+\\)\n$"
+	expectedRegExp := "- \\[.+\\.go:[0-9]+\\]\\[.+\\(\\)\\] \\[DEBU\\] test1\n$"
 	match, err := regexp.MatchString(
 		expectedRegExp,
 		line,


### PR DESCRIPTION
Added 2 options
  - CallerFirst bool : to print caller info at the beginning of log (right before log level)
  - CustomCallerPrettyfier func(*runtime.Frame) string : to use custom caller prettyfier function

tests/formatter_test.go also updated with 2 test functions.