### PR TITLE
Add NoUppercaseLevel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ type Formatter struct {
 	// ShowFullLevel - show a full level [WARNING] instead of [WARN]
 	ShowFullLevel bool
 
+	// NoUppercaseLevel - no upper case for level value
+	NoUppercaseLevel bool
+
 	// TrimMessages - trim whitespaces on messages
 	TrimMessages bool
 

--- a/formatter.go
+++ b/formatter.go
@@ -34,6 +34,9 @@ type Formatter struct {
 	// ShowFullLevel - show a full level [WARNING] instead of [WARN]
 	ShowFullLevel bool
 
+	// NoUppercaseLevel - no upper case for level value
+	NoUppercaseLevel bool
+
 	// TrimMessages - trim whitespaces on messages
 	TrimMessages bool
 
@@ -60,7 +63,12 @@ func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
 	b.WriteString(entry.Time.Format(timestampFormat))
 
 	// write level
-	level := strings.ToUpper(entry.Level.String())
+	var level string
+	if f.NoUppercaseLevel {
+		level = entry.Level.String()
+	} else {
+		level = strings.ToUpper(entry.Level.String())
+	}
 
 	if f.CallerFirst {
 		f.writeCaller(b, entry)

--- a/tests/formatter_test.go
+++ b/tests/formatter_test.go
@@ -168,6 +168,33 @@ func ExampleFormatter_Format_no_fields_space() {
 	// - [INFO][component:main][category:rest] test3
 }
 
+func ExampleFormatter_Format_no_uppercase_level() {
+	l := logrus.New()
+	l.SetOutput(os.Stdout)
+	l.SetLevel(logrus.DebugLevel)
+	l.SetFormatter(&formatter.Formatter{
+		NoColors:         true,
+		TimestampFormat:  "-",
+		FieldsOrder:      []string{"component", "category"},
+		NoUppercaseLevel: true,
+	})
+
+	ll := l.WithField("component", "main")
+	lll := ll.WithField("category", "rest")
+	llll := ll.WithField("category", "other")
+
+	l.Debug("test1")
+	ll.Info("test2")
+	lll.Warn("test3")
+	llll.Error("test4")
+
+	// Output:
+	// - [debu] test1
+	// - [info] [component:main] test2
+	// - [warn] [component:main] [category:rest] test3
+	// - [erro] [component:main] [category:other] test4
+}
+
 func ExampleFormatter_Format_trim_message() {
 	l := logrus.New()
 	l.SetOutput(os.Stdout)


### PR DESCRIPTION
A small but usable log level formatting option, for those who don't want to see it upper case.
Being set to "true", it doesn't transform the original level value.
```
Sep 11 01:37:19.892 [info] this is nested-logrus-formatter demo
Sep 11 01:37:19.893 [info] [web-server] starting...
Sep 11 01:37:19.893 [info] [web-server] [GET /api/stats] [#1] params: startYear=2048
Sep 11 01:37:19.893 [erro] [web-server] [GET /api/stats] [#1] response: 400 Bad Request
Sep 11 01:37:19.893 [info] [db-connector] connecting to db on 10.10.10.13...
Sep 11 01:37:19.893 [warn] [db-connector] connection took 10s
Sep 11 01:37:19.893 [info] demo end.
```