### PR TITLE
Trace log level color with gray, same as debug

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -204,7 +204,7 @@ const (
 
 func getColorByLevel(level logrus.Level) int {
 	switch level {
-	case logrus.DebugLevel:
+	case logrus.DebugLevel, logrus.TraceLevel:
 		return colorGray
 	case logrus.WarnLevel:
 		return colorYellow


### PR DESCRIPTION
Currently, the Trace level is logged as blue, the same as Info. I think it should be similar to Logrus, which has a Gray color for Debug and Trace as well.