### PR TITLE
Add SkipFields option

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -13,6 +13,9 @@ import (
 
 // Formatter - logrus formatter, implements logrus.Formatter
 type Formatter struct {
+	// SkipFields - default: no fields
+	SkipFields []string
+
 	// FieldsOrder - default: fields sorted alphabetically
 	FieldsOrder []string
 
@@ -184,6 +187,12 @@ func (f *Formatter) writeOrderedFields(b *bytes.Buffer, entry *logrus.Entry) {
 }
 
 func (f *Formatter) writeField(b *bytes.Buffer, entry *logrus.Entry, field string) {
+	for _, fieldToSkip := range f.SkipFields {
+		if field == fieldToSkip {
+			return
+		}
+	}
+
 	if f.HideKeys {
 		fmt.Fprintf(b, "[%v]", entry.Data[field])
 	} else {


### PR DESCRIPTION
Adds a SkipFields option which omits the given fields from standard output. This is useful if you have a CloudWatch hook and want certain fields to be included in the CloudWatch logs, but not in the standard output.

For my circumstance, I omitted correlation ID equivalent fields, which are useful in logs, but is excessive detail in the standard output.