### PR TITLE
Add support for multiline messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ type Formatter struct {
 	// TrimMessages - trim whitespaces on messages
 	TrimMessages bool
 
+	// MetaPerLine - write metadata and fields for each line of the message
+	MetaPerLine bool
+
 	// CallerFirst - print caller info first
 	CallerFirst bool
 


### PR DESCRIPTION
Currently when a message has many lines, most of the lines get printed as is, without date, level, fields, caller, etc.
Example:
```go
ll.Info(`line 1
line 2
line 3`)
```
Output:
```
- [INFO] [test:field] line 1
line 2
line 3
```
With new option `MetaPerLine` set to `true` the output is more consistent:
```
- [INFO] [test:field] line 1
- [INFO] [test:field] line 2
- [INFO] [test:field] line 3
```
